### PR TITLE
Make mkdir verbose, add optimizations and native processor compilatio…

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 ###################################################
 
 compiler = clang
-options  = 
-linker   = -lluajit-5.1
+options  = -march=native -O3 -flto=thin -fsanitize=scudo -pipe
+linker   = -lluajit-5.1 -Wl,-O3
 output   = leaf
 sources  = ./src/main.c
 
@@ -17,27 +17,27 @@ clean:
 ###################################################
 
 install:
-	mkdir -p /usr/lib/sdx6/$(output)/
+	mkdir -pv /usr/lib/sdx6/$(output)/
 	luajit -b ./src/main.lua /usr/lib/sdx6/$(output)/main.lua
-	mkdir -p /usr/local/bin/
+	mkdir -pv /usr/local/bin/
 	cp ./src/$(output) /usr/local/bin/
-	mkdir -p /etc/xdg/sdx6/$(output)/
+	mkdir -pv /etc/xdg/sdx6/$(output)/
 	cp ./xdg/config.lua /etc/xdg/sdx6/$(output)/
 
 ###################################################
 
 local:
-	mkdir -p ~/.local/bin/
+	mkdir -pv ~/.local/bin/
 	cp ./src/$(output) ~/.local/bin/
-	mkdir -p ~/.local/share/sdx6/$(output)/
+	mkdir -pv ~/.local/share/sdx6/$(output)/
 	luajit -b ./src/main.lua ~/.local/share/sdx6/$(output)/main.lua
 
 ###################################################
 
 test:
-	mkdir -p /usr/lib/sdx6/$(output)/
+	mkdir -pv /usr/lib/sdx6/$(output)/
 	luajit -b ./src/main.lua /usr/lib/sdx6/$(output)/main.lua
-	mkdir -p /usr/local/bin/
+	mkdir -pv /usr/local/bin/
 	$(compiler) $(options) -o /usr/local/bin/$(output) $(sources) $(linker)
 
 ###################################################


### PR DESCRIPTION
This should add verbosity to the mkdir actions, add compiler optimizations along with linker optimizations, LTO, the Scudo memory allocator for better performance and piping to avoid writing to disk while compiling.